### PR TITLE
Improved dashboard

### DIFF
--- a/BSM/BorealisServerManager.csproj
+++ b/BSM/BorealisServerManager.csproj
@@ -47,6 +47,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>DEPENDENCIES\MetroFramework.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/BSM/BorealisServerManager.csproj
+++ b/BSM/BorealisServerManager.csproj
@@ -47,6 +47,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>DEPENDENCIES\MetroFramework.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -153,6 +157,7 @@
       <DependentUpon>ServerControl.cs</DependentUpon>
     </EmbeddedResource>
     <None Include="app.manifest" />
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/BSM/CLASSES/MonitoringFunctions.cs
+++ b/BSM/CLASSES/MonitoringFunctions.cs
@@ -86,17 +86,21 @@ namespace Borealis
         public int RetrieveCPUUsage()
         {
             // http://stackoverflow.com/questions/9777661/returning-cpu-usage-in-wmi-using-c-sharp
-            ManagementObjectSearcher searcher = new ManagementObjectSearcher("select * from Win32_PerfFormattedData_PerfOS_Processor");
-
-            var count = 0;
-            var mean = 0;
-            foreach (ManagementObject obj in searcher.Get())
+            using (var searcher = new ManagementObjectSearcher("select * from Win32_PerfFormattedData_PerfOS_Processor"))
             {
-                //We only care about the first value
-                mean += Convert.ToInt32(obj["PercentProcessorTime"]);
-                count++;
+                var count = 0;
+                var mean = 0;
+                var collection = searcher.Get();
+                foreach (ManagementObject obj in collection)
+                {
+                    //We only care about the first value
+                    mean += Convert.ToInt32(obj["PercentProcessorTime"]);
+                    count++;
+                    obj.Dispose();
+                }
+                collection.Dispose();
+                return mean / count;
             }
-            return mean / count;
         }
     }
 }

--- a/BSM/CLASSES/MonitoringFunctions.cs
+++ b/BSM/CLASSES/MonitoringFunctions.cs
@@ -7,6 +7,11 @@ using System.Diagnostics;
 using System.IO;
 using System.Timers;
 using System.Windows.Forms;
+using Microsoft.VisualBasic.Devices;
+using System.Threading;
+using System.Management;
+
+using System.Linq;
 
 namespace Borealis
 {
@@ -15,11 +20,16 @@ namespace Borealis
         //===================================================================================//
         // RAM UTILIZATION INFO FUNCTIONS                                                    //
         //===================================================================================//
-        public string RetrieveRAMUsage(bool OverallUsage, bool IndividualUsage)
+        public long RetreiveFreeRAM()
         {
-            PerformanceCounter ramCounter;
-            ramCounter = new PerformanceCounter("Memory", "Available MBytes");
-            return Convert.ToString(ramCounter.NextValue());
+            var info = new ComputerInfo();
+            return (long)(info.AvailablePhysicalMemory / 1024 / 1024);
+        }
+
+        public long RetreiveTotalAvailableRAM()
+        {
+            var info = new ComputerInfo();
+            return (long)(info.TotalPhysicalMemory / 1024 / 1024);
         }
 
         //===================================================================================//
@@ -73,15 +83,20 @@ namespace Borealis
         //===================================================================================//
         // CPU UTILIZATION INFO FUNCTIONS                                                    //
         //===================================================================================//
-        public int RetrieveCPUUsage(bool OverallUsage, bool IndividualUsage)
+        public int RetrieveCPUUsage()
         {
-            PerformanceCounter cpuCounter;
-            cpuCounter = new PerformanceCounter();
-            cpuCounter.CategoryName = "Processor";
-            cpuCounter.CounterName = "% Processor Time";
-            cpuCounter.InstanceName = "_Total";
-            return (int)cpuCounter.NextValue();
-        }
+            // http://stackoverflow.com/questions/9777661/returning-cpu-usage-in-wmi-using-c-sharp
+            ManagementObjectSearcher searcher = new ManagementObjectSearcher("select * from Win32_PerfFormattedData_PerfOS_Processor");
 
+            var count = 0;
+            var mean = 0;
+            foreach (ManagementObject obj in searcher.Get())
+            {
+                //We only care about the first value
+                mean += Convert.ToInt32(obj["PercentProcessorTime"]);
+                count++;
+            }
+            return mean / count;
+        }
     }
 }

--- a/BSM/MODULES/ServerDashboard.Designer.cs
+++ b/BSM/MODULES/ServerDashboard.Designer.cs
@@ -42,11 +42,6 @@
             this.bunifuCustomLabel5 = new Bunifu.Framework.UI.BunifuCustomLabel();
             this.bunifuCustomLabel2 = new Bunifu.Framework.UI.BunifuCustomLabel();
             this.overallServerStatsGrid = new Bunifu.Framework.UI.BunifuCustomDataGrid();
-            this.backgroundMetrics = new System.ComponentModel.BackgroundWorker();
-            this.panelMemoryUsage = new System.Windows.Forms.Panel();
-            this.panelDiskUsage = new System.Windows.Forms.Panel();
-            this.panelCPUUsage = new System.Windows.Forms.Panel();
-            this.bunifuCustomLabel3 = new Bunifu.Framework.UI.BunifuCustomLabel();
             this.columnGameServerName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnGameServerRAM = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnGameServerDISK = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -54,9 +49,14 @@
             this.columnNetworkUsage = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnRestartFlag = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.progressDISKUsage = new Bunifu.Framework.UI.BunifuCircleProgressbar();
-            this.progressCPUUsage = new Bunifu.Framework.UI.BunifuCircleProgressbar();
+            this.backgroundMetrics = new System.ComponentModel.BackgroundWorker();
+            this.panelMemoryUsage = new System.Windows.Forms.Panel();
             this.progressRAMUsage = new Bunifu.Framework.UI.BunifuCircleProgressbar();
+            this.panelDiskUsage = new System.Windows.Forms.Panel();
+            this.progressDISKUsage = new Bunifu.Framework.UI.BunifuCircleProgressbar();
+            this.panelCPUUsage = new System.Windows.Forms.Panel();
+            this.progressCPUUsage = new Bunifu.Framework.UI.BunifuCircleProgressbar();
+            this.bunifuCustomLabel3 = new Bunifu.Framework.UI.BunifuCustomLabel();
             ((System.ComponentModel.ISupportInitialize)(this.overallServerStatsGrid)).BeginInit();
             this.panelMemoryUsage.SuspendLayout();
             this.panelDiskUsage.SuspendLayout();
@@ -225,52 +225,6 @@
             this.overallServerStatsGrid.Size = new System.Drawing.Size(700, 223);
             this.overallServerStatsGrid.TabIndex = 43;
             // 
-            // backgroundMetrics
-            // 
-            this.backgroundMetrics.DoWork += new System.ComponentModel.DoWorkEventHandler(this.backgroundMetrics_DoWork);
-            // 
-            // panelMemoryUsage
-            // 
-            this.panelMemoryUsage.Controls.Add(this.progressRAMUsage);
-            this.panelMemoryUsage.Controls.Add(this.lblDetailedRAMUsage);
-            this.panelMemoryUsage.Controls.Add(this.lblRAMUsage);
-            this.panelMemoryUsage.Location = new System.Drawing.Point(23, 68);
-            this.panelMemoryUsage.Name = "panelMemoryUsage";
-            this.panelMemoryUsage.Size = new System.Drawing.Size(200, 205);
-            this.panelMemoryUsage.TabIndex = 61;
-            // 
-            // panelDiskUsage
-            // 
-            this.panelDiskUsage.Controls.Add(this.progressDISKUsage);
-            this.panelDiskUsage.Controls.Add(this.lblDISKUsage);
-            this.panelDiskUsage.Controls.Add(this.lblDetailedDISKUsage);
-            this.panelDiskUsage.Location = new System.Drawing.Point(248, 68);
-            this.panelDiskUsage.Name = "panelDiskUsage";
-            this.panelDiskUsage.Size = new System.Drawing.Size(200, 205);
-            this.panelDiskUsage.TabIndex = 62;
-            // 
-            // panelCPUUsage
-            // 
-            this.panelCPUUsage.Controls.Add(this.progressCPUUsage);
-            this.panelCPUUsage.Controls.Add(this.lblCPUUsage);
-            this.panelCPUUsage.Controls.Add(this.lblDetailedCPUUsage);
-            this.panelCPUUsage.Location = new System.Drawing.Point(472, 68);
-            this.panelCPUUsage.Name = "panelCPUUsage";
-            this.panelCPUUsage.Size = new System.Drawing.Size(200, 205);
-            this.panelCPUUsage.TabIndex = 62;
-            // 
-            // bunifuCustomLabel3
-            // 
-            this.bunifuCustomLabel3.AutoSize = true;
-            this.bunifuCustomLabel3.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(238)))), ((int)(((byte)(239)))), ((int)(((byte)(242)))));
-            this.bunifuCustomLabel3.Font = new System.Drawing.Font("Segoe UI Light", 10F);
-            this.bunifuCustomLabel3.ForeColor = System.Drawing.Color.Red;
-            this.bunifuCustomLabel3.Location = new System.Drawing.Point(257, 20);
-            this.bunifuCustomLabel3.Name = "bunifuCustomLabel3";
-            this.bunifuCustomLabel3.Size = new System.Drawing.Size(293, 19);
-            this.bunifuCustomLabel3.TabIndex = 63;
-            this.bunifuCustomLabel3.Text = "(Disabled at the moment due to a memory leak)";
-            // 
             // columnGameServerName
             // 
             this.columnGameServerName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
@@ -320,6 +274,54 @@
             this.columnRestartFlag.Name = "columnRestartFlag";
             this.columnRestartFlag.ReadOnly = true;
             // 
+            // backgroundMetrics
+            // 
+            this.backgroundMetrics.WorkerReportsProgress = true;
+            this.backgroundMetrics.DoWork += new System.ComponentModel.DoWorkEventHandler(this.backgroundMetrics_DoWork);
+            this.backgroundMetrics.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this.backgroundMetrics_ProgressChanged);
+            // 
+            // panelMemoryUsage
+            // 
+            this.panelMemoryUsage.Controls.Add(this.progressRAMUsage);
+            this.panelMemoryUsage.Controls.Add(this.lblDetailedRAMUsage);
+            this.panelMemoryUsage.Controls.Add(this.lblRAMUsage);
+            this.panelMemoryUsage.Location = new System.Drawing.Point(23, 68);
+            this.panelMemoryUsage.Name = "panelMemoryUsage";
+            this.panelMemoryUsage.Size = new System.Drawing.Size(200, 205);
+            this.panelMemoryUsage.TabIndex = 61;
+            // 
+            // progressRAMUsage
+            // 
+            this.progressRAMUsage.animated = true;
+            this.progressRAMUsage.animationIterval = 1;
+            this.progressRAMUsage.animationSpeed = 60;
+            this.progressRAMUsage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(238)))), ((int)(((byte)(239)))), ((int)(((byte)(242)))));
+            this.progressRAMUsage.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("progressRAMUsage.BackgroundImage")));
+            this.progressRAMUsage.Font = new System.Drawing.Font("Segoe UI", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.progressRAMUsage.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(100)))), ((int)(((byte)(100)))));
+            this.progressRAMUsage.LabelVisible = true;
+            this.progressRAMUsage.LineProgressThickness = 8;
+            this.progressRAMUsage.LineThickness = 5;
+            this.progressRAMUsage.Location = new System.Drawing.Point(23, 1);
+            this.progressRAMUsage.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            this.progressRAMUsage.MaxValue = 100;
+            this.progressRAMUsage.Name = "progressRAMUsage";
+            this.progressRAMUsage.ProgressBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(208)))), ((int)(((byte)(209)))), ((int)(((byte)(212)))));
+            this.progressRAMUsage.ProgressColor = System.Drawing.Color.FromArgb(((int)(((byte)(67)))), ((int)(((byte)(181)))), ((int)(((byte)(129)))));
+            this.progressRAMUsage.Size = new System.Drawing.Size(155, 155);
+            this.progressRAMUsage.TabIndex = 49;
+            this.progressRAMUsage.Value = 0;
+            // 
+            // panelDiskUsage
+            // 
+            this.panelDiskUsage.Controls.Add(this.progressDISKUsage);
+            this.panelDiskUsage.Controls.Add(this.lblDISKUsage);
+            this.panelDiskUsage.Controls.Add(this.lblDetailedDISKUsage);
+            this.panelDiskUsage.Location = new System.Drawing.Point(248, 68);
+            this.panelDiskUsage.Name = "panelDiskUsage";
+            this.panelDiskUsage.Size = new System.Drawing.Size(200, 205);
+            this.panelDiskUsage.TabIndex = 62;
+            // 
             // progressDISKUsage
             // 
             this.progressDISKUsage.animated = true;
@@ -341,6 +343,16 @@
             this.progressDISKUsage.Size = new System.Drawing.Size(155, 155);
             this.progressDISKUsage.TabIndex = 52;
             this.progressDISKUsage.Value = 0;
+            // 
+            // panelCPUUsage
+            // 
+            this.panelCPUUsage.Controls.Add(this.progressCPUUsage);
+            this.panelCPUUsage.Controls.Add(this.lblCPUUsage);
+            this.panelCPUUsage.Controls.Add(this.lblDetailedCPUUsage);
+            this.panelCPUUsage.Location = new System.Drawing.Point(472, 68);
+            this.panelCPUUsage.Name = "panelCPUUsage";
+            this.panelCPUUsage.Size = new System.Drawing.Size(200, 205);
+            this.panelCPUUsage.TabIndex = 62;
             // 
             // progressCPUUsage
             // 
@@ -364,27 +376,17 @@
             this.progressCPUUsage.TabIndex = 55;
             this.progressCPUUsage.Value = 0;
             // 
-            // progressRAMUsage
+            // bunifuCustomLabel3
             // 
-            this.progressRAMUsage.animated = true;
-            this.progressRAMUsage.animationIterval = 1;
-            this.progressRAMUsage.animationSpeed = 60;
-            this.progressRAMUsage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(238)))), ((int)(((byte)(239)))), ((int)(((byte)(242)))));
-            this.progressRAMUsage.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("progressRAMUsage.BackgroundImage")));
-            this.progressRAMUsage.Font = new System.Drawing.Font("Segoe UI", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.progressRAMUsage.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(100)))), ((int)(((byte)(100)))));
-            this.progressRAMUsage.LabelVisible = true;
-            this.progressRAMUsage.LineProgressThickness = 8;
-            this.progressRAMUsage.LineThickness = 5;
-            this.progressRAMUsage.Location = new System.Drawing.Point(23, 1);
-            this.progressRAMUsage.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
-            this.progressRAMUsage.MaxValue = 100;
-            this.progressRAMUsage.Name = "progressRAMUsage";
-            this.progressRAMUsage.ProgressBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(208)))), ((int)(((byte)(209)))), ((int)(((byte)(212)))));
-            this.progressRAMUsage.ProgressColor = System.Drawing.Color.FromArgb(((int)(((byte)(67)))), ((int)(((byte)(181)))), ((int)(((byte)(129)))));
-            this.progressRAMUsage.Size = new System.Drawing.Size(155, 155);
-            this.progressRAMUsage.TabIndex = 49;
-            this.progressRAMUsage.Value = 0;
+            this.bunifuCustomLabel3.AutoSize = true;
+            this.bunifuCustomLabel3.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(238)))), ((int)(((byte)(239)))), ((int)(((byte)(242)))));
+            this.bunifuCustomLabel3.Font = new System.Drawing.Font("Segoe UI Light", 10F);
+            this.bunifuCustomLabel3.ForeColor = System.Drawing.Color.Red;
+            this.bunifuCustomLabel3.Location = new System.Drawing.Point(257, 20);
+            this.bunifuCustomLabel3.Name = "bunifuCustomLabel3";
+            this.bunifuCustomLabel3.Size = new System.Drawing.Size(293, 19);
+            this.bunifuCustomLabel3.TabIndex = 63;
+            this.bunifuCustomLabel3.Text = "(Disabled at the moment due to a memory leak)";
             // 
             // ServerDashboard
             // 

--- a/BSM/MODULES/ServerDashboard.cs
+++ b/BSM/MODULES/ServerDashboard.cs
@@ -52,7 +52,7 @@ namespace Borealis
             BackgroundWorker worker = (BackgroundWorker)sender;
             while (!worker.CancellationPending)
             {
-                Thread.Sleep(10);
+                Thread.Sleep(500);
                 _dashboardInfo = GetInfo();
                 worker.ReportProgress(0, "AN OBJECT TO PASS TO THE UI-THREAD");
             }

--- a/BSM/packages.config
+++ b/BSM/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
I tried fixing the dashboard for real time info about disk usage / mem usage / cpu.

`PerformanceCounter` was the cause of the memory leak, as it's an `IDisposable` it should be disposed or wrapped inside an `using` statetement.

I replaced it with `ComputerInfo` for the memory and `ManagementObjectSearcher` for CPU info.
`ManagementObjectSearcher` could also be a source of memory leaks, that's why I dispose everything that it produces.

Memory seems to be stable at about ~89MB on my computer.